### PR TITLE
Adding topics to the output of the crawler

### DIFF
--- a/crawler.rb
+++ b/crawler.rb
@@ -28,6 +28,7 @@ end
 # Auth to GitHub.com
 client = Octokit::Client.new(:access_token => ENV['GH_TOKEN'])
 client.auto_paginate = true
+client.default_media_type = "application/vnd.github.mercy-preview+json"
 
 # Get repos for the configured ORGANIZATION and TOPIC
 # Note: The GitHub Search API limits search results to max 1.000 repos.


### PR DESCRIPTION
I found this other portal implementation:
[enterprise-showcase](https://github.com/helaili/enterprise-showcase)

Now I am trying to make the output of **innersource-crawler-ruby** compatible with that portal too. That would allow users to quickly try out both portals, using the same crawler.

The [enterprise-showcase](https://github.com/helaili/enterprise-showcase) requires each repo object to have a `topics` property.
That property can be returned by the GitHub API for all repo objects by using the media type "application/vnd.github.mercy-preview+json" (see [docs](https://docs.github.com/en/rest/reference/repos#get-all-repository-topics)).
